### PR TITLE
Voting Compatibility & About DisplayName

### DIFF
--- a/src/main/java/chronometry/MonsterMessageRepeater.java
+++ b/src/main/java/chronometry/MonsterMessageRepeater.java
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.regex.Pattern;
 
 public class MonsterMessageRepeater {
 
@@ -49,12 +50,12 @@ public class MonsterMessageRepeater {
 		if (CardCrawlGame.isInARun()) {
 			if (AbstractDungeon.getCurrRoom() != null) {
 				if (AbstractDungeon.getCurrRoom().monsters != null) {
-                    Iterator var1 = AbstractDungeon.getCurrRoom().monsters.monsters.iterator();
-                    AbstractMonster m;
+					Iterator var1 = AbstractDungeon.getCurrRoom().monsters.monsters.iterator();
+					AbstractMonster m;
 					while (var1.hasNext()) {
-					    m = (AbstractMonster)var1.next();
-						SlayTheStreamer.logger.info("parseMessage: monster ".concat(m.name).concat(" isDying ")
-								.concat(String.valueOf(m.isDying)).concat(" isPlayer ")
+						m = (AbstractMonster)var1.next();
+						SlayTheStreamer.logger.info("parseMessage: monster ".concat(m.name).concat(" isDying = ")
+								.concat(String.valueOf(m.isDying)).concat(", isPlayer = ")
 								.concat(String.valueOf(AbstractMonsterPatch.is_player.get(m))));
 						if (m.isDying) { continue; }
 						String username = user;
@@ -62,8 +63,15 @@ public class MonsterMessageRepeater {
 							username = SlayTheStreamer.displayNames.get(username);
 						}
 						if (m.name.split(" ")[0].toLowerCase().equals(username.split(" ")[0].toLowerCase())) {
-							if (msg.startsWith("#") && !AbstractMonsterPatch.had_turn.get(m)) {
-								msg = msg.substring(1).replaceAll("\\s", "_").toLowerCase();
+							SlayTheStreamer.logger.info(
+									"pattern: match - " +
+											Pattern.matches(SlayTheStreamer.movePatternChecker, msg) +
+											", " +	"replaced: " +
+											msg.replaceAll(SlayTheStreamer.movePatternExtractor, "").
+													replaceAll("\\s", "_").toLowerCase() );
+							if (Pattern.matches(SlayTheStreamer.movePatternChecker, msg) && !AbstractMonsterPatch.had_turn.get(m)) {
+								msg = msg.replaceAll(SlayTheStreamer.movePatternExtractor, "").
+										replaceAll("\\s", "_").toLowerCase();
 								ArrayList<IntentData> moves = IntentData.getAvailableMoves(m);
 								for (int num = 0; num < moves.size(); num++) {
 									IntentData data = moves.get(num);

--- a/src/main/java/chronometry/SlayTheStreamer.java
+++ b/src/main/java/chronometry/SlayTheStreamer.java
@@ -33,9 +33,9 @@ import de.robojumper.ststwitch.*;
 
 import com.google.gson.Gson;
 
-    // TODO:
-    //   Active monsters could have a listener that lets the user talk on screen
-    //crashes if you try to restart the run
+// TODO:
+//   Active monsters could have a listener that lets the user talk on screen
+//crashes if you try to restart the run
 
 @SpireInitializer
 public class SlayTheStreamer implements PostInitializeSubscriber, StartGameSubscriber,
@@ -59,6 +59,11 @@ public class SlayTheStreamer implements PostInitializeSubscriber, StartGameSubsc
     public static Map<String, Integer> votedTimes = new HashMap();  // displayname, voted times
     public static HashMap<String, HashMap<String, String>> localizedMonsterMoves;
     public static HashMap<String, String> localizedChatEffects;
+
+    public static String movePatternBase = "";
+    public static String movePatternChecker = "";
+    public static String movePatternExtractor = "";
+
 
     @SuppressWarnings("deprecation")
     public SlayTheStreamer() {
@@ -153,12 +158,12 @@ public class SlayTheStreamer implements PostInitializeSubscriber, StartGameSubsc
         // Remove Pandora's Box
         for (Iterator<String> s = AbstractDungeon.bossRelicPool.iterator(); s.hasNext();)
         {
-          String derp = (String)s.next();
-          if (derp.equals("Pandora's Box"))
-          {
-            s.remove();
-            break;
-          }
+            String derp = (String)s.next();
+            if (derp.equals("Pandora's Box"))
+            {
+                s.remove();
+                break;
+            }
         }
 
         // Set us to trial mode so we don't get Neow bonuses
@@ -211,7 +216,7 @@ public class SlayTheStreamer implements PostInitializeSubscriber, StartGameSubsc
     public void receiveEditStrings() {
         String path = "localization/";
 
-        switch(Settings.language.toString()){
+        switch(Settings.language.toString()){ // set path by language
             case "RUS":
             case "KOR":
                 path = path.concat(Settings.language.toString().toLowerCase());
@@ -222,6 +227,20 @@ public class SlayTheStreamer implements PostInitializeSubscriber, StartGameSubsc
                 break;
         }
 
+        movePatternBase = "(#";
+        switch(Settings.language.toString()){ // set patternMatcher by language
+            case "RUS":
+                break;
+            case "KOR":
+                movePatternBase = movePatternBase.concat("|x|ㅌ|투표");
+                break;
+            case "ENG":
+            default:
+                break;
+        }
+        movePatternBase = movePatternBase.concat(")");
+        movePatternChecker = "^" + movePatternBase + ".*$"; // pattern checker
+        movePatternExtractor = "^" + movePatternBase; // pattern remover
 
         Type tokenType = new TypeToken<HashMap<String, HashMap<String, String>>>() {}.getType();
         SlayTheStreamer.localizedMonsterMoves = new HashMap<>(

--- a/src/main/java/chronometry/patches/MonsterNamesPatch.java
+++ b/src/main/java/chronometry/patches/MonsterNamesPatch.java
@@ -137,9 +137,7 @@ public class MonsterNamesPatch {
     public static class storeTwitchNames {
     	@SpireInsertPatch( rloc = 33, localvars={"user"} )
         public static void Insert(Twirk self, String line, TwitchUser user) {
-			if (user.getDisplayName().matches("\\w+")) {
-				SlayTheStreamer.displayNames.put(user.getUserName(), user.getDisplayName());
-			}
+			SlayTheStreamer.displayNames.put(user.getUserName(), user.getDisplayName());
         }
     }
 


### PR DESCRIPTION
### Make Voting More Compatible

- Some viewer (especially mobile viewer) is hard to type `#` and a number or move in the limited voting time

- SlayTheStreamer.java
  - `movePatternBase`
    - `"(#|<other>|<things>")` ex) `(#|vote |V)`
    - Maybe can use .json to localization if you aren't mind merging this
  - `movePatternChecker`
    - Automatically set to `^<movePatternBase>.*$`
    - Use `Pattern.matches(SlayTheStreamer.movePatternChecker, <targetString>)` to check whether the `<targetString>` starts with the pattern
    - When the `movePatternBase` is `(#|vote |V)` then, `vote tackle`, `vote Test and so on`, `V1`, and `# 123` will return true, `vote1`, ` V1`, `hello #2`, `_V2`and others will return false (consider `_` as whitespace)
  - `movePatternExtractor`
    - Automatically set to `^<movePatternBase>`
    - Use `<targetString>.replaceAll(SlayTheStreamer.movePatternExtractor, "")` to remove all starting pattern
    - When the `movePatternBase` is `(#|vote |V)` then, `vote tackle` will be `tackle`, `vote Test and so on` will be `Test and so on`, `V1` will be `1`, and `# 123` will be `_123` while `vote1`, ` V1`, `hello #2`, `_V2` and others nothing happen. (consider `_` as whitespace)
  - Things above is applied, and value are set at `recieveEditStrings`

- MonsterMessageRepeater.java
  - Applied the things above, checking and removing

### Korean Nickname error
- MonsterNamesPatch.java
```java
if (user.getDisplayName().matches("\\w+")) {
	SlayTheStreamer.displayNames.put(user.getUserName(), user.getDisplayName());
}
```
- Removed condition
```java
SlayTheStreamer.displayNames.put(user.getUserName(), user.getDisplayName());
```
- With that, Korean `DisplayName` is not in the condition.
- However I found it was committed with `not-latin displaynames fix`
- Umm...